### PR TITLE
Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+# Multi-staged build of Spotifyd on Alpine Linux
+
+FROM arm32v7/alpine:latest AS build
+WORKDIR /tmp
+RUN apk update && apk add alsa-lib libvorbis libgcc openssl-dev alsa-lib-dev rust cargo && \
+	wget https://github.com/Spotifyd/spotifyd/archive/master.zip && \
+	unzip master.zip && cd spotifyd-master && cargo build --release
+
 FROM arm32v7/alpine:latest
-
 LABEL maintainer="np@bitbox.io"
-
-RUN apk update && apk add --no-cache libc6-compat libgcc curl alsa-lib libvorbis && \
-	RUN apk add --no-cache libc6-compat libgcc curl alsa-lib libvorbis && \
-	curl -L `curl --silent https://api.github.com/repos/spotifyd/spotifyd/releases/latest | \
-	/usr/bin/awk '/browser_download_url/ { print $2 }' | \
-	egrep "armv6.*tar.gz" | /bin/sed 's/"//g'` > /tmp/spotifyd.tgz && \
-	cd /usr/bin && tar -xzf /tmp/spotifyd.tgz && rm /tmp/spotifyd.tgz && \
-	apk del curl
-RUN addgroup daemon audio
-
+RUN apk update && apk upgrade && apk add --no-cache alsa-lib libvorbis libgcc && rm -f /var/cache/apk/* && \
+	addgroup daemon audio && mkdir /var/cache/spotifyd && chown daemon.audio /var/cache/spotifyd
+COPY --from=build /tmp/spotifyd-master/target/release/spotifyd /usr/bin/.
 USER daemon
 ENTRYPOINT ["/usr/bin/spotifyd", "--no-daemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM arm32v7/debian:stable-slim
+FROM arm32v7/alpine:latest
 
 LABEL maintainer="np@bitbox.io"
 
-RUN apt-get -qq update && apt-get -qq upgrade && apt-get -qq install locales curl libasound2 libvorbisfile3 && \
-	rm -rf /var/lib/apt/lists/* && \
-	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
-RUN curl -L `curl --silent https://api.github.com/repos/spotifyd/spotifyd/releases/latest | /usr/bin/awk '/browser_download_url/ { print $2 }'|egrep "armv6.*tar.gz"|/bin/sed 's/"//g'` > /tmp/spotifyd.tgz && \
+RUN apk update && apk add --no-cache libc6-compat libgcc curl alsa-lib libvorbis && \
+	RUN apk add --no-cache libc6-compat libgcc curl alsa-lib libvorbis && \
+	curl -L `curl --silent https://api.github.com/repos/spotifyd/spotifyd/releases/latest | \
+	/usr/bin/awk '/browser_download_url/ { print $2 }' | \
+	egrep "armv6.*tar.gz" | /bin/sed 's/"//g'` > /tmp/spotifyd.tgz && \
 	cd /usr/bin && tar -xzf /tmp/spotifyd.tgz && rm /tmp/spotifyd.tgz && \
-	apt-get -qq purge curl && apt-get clean && \
-	usermod -a -G audio daemon
+	apk del curl
+RUN addgroup daemon audio
 
 USER daemon
 ENTRYPOINT ["/usr/bin/spotifyd", "--no-daemon"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # A Docker image for Spotifyd on Raspberry Pi
 
-Built image relies on pre-compiled binaries pulled from https://github.com/Spotifyd/spotifyd.
+spotifyMyPi builds a Docker image of [Spotifyd](https://github.com/Spotifyd/spotifyd) from source, pulled from the master branch.
+The base image is now based on [Alpine Linux](https://alpinelinux.org).
 
 
 ### Build it
@@ -12,10 +13,21 @@ chmod +x do.sh
 sudo ./do.sh build
 ```
 
+If you're satisfied with the result, you'll want to remove the intermediary _build_ image, which can grow rather extensively.
+```
+sudo docker image prune 
+```
 
 ### Configure it
 
 Copy then edit `conf/spotifyd.conf` in `/opt/spotifyd/etc`. You'll need to set your Spotify Premium accounts details, as well as your sound card Alsa identifier.
+
+**Alignment of the _audio_ GUID
+If you're running Docker on a debian-based system (typically Raspbian), you'll need to align the GUID of the _audio_ group on your host system with Alpine's. On your host system, run `sudo vigr` and change the GUID for _audio_ to 18. Failing to do so will result in the service not being able to access the soundcard device.
+```
+$ grep audio /etc/group
+audio:x:18:
+```
 
 
 ### Run it
@@ -36,7 +48,7 @@ sudo systemctl start spotifyd
 
 ### Update the image
 
-The following command will rebuild a new image using the latest Spotifyd binaries and an updated base image.
+The following command will rebuild a new image using updated source code and base image.
 
 ```
 sudo ./do.sh update

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Docker image for Spotifyd on Raspberry Pi
 
-spotifyMyPi builds a Docker image of [Spotifyd](https://github.com/Spotifyd/spotifyd) from source, pulled from the master branch.
+_spotifyMyPi_ builds a Docker image of [Spotifyd](https://github.com/Spotifyd/spotifyd) from source, pulled from the master branch.
 The base image is now based on [Alpine Linux](https://alpinelinux.org).
 
 
@@ -79,4 +79,4 @@ WantedBy=multi-user.target [your DAC's device unit name here]
 
 Please note that modifying the *Install* section of an existing unit file will require re-enabling the unit, not just daemon-reloading systemd.
 
-The Spotifyd container should now be started when your DAC is powered on, stopped when powered off.
+The _spotifyd_ container should now be started when your DAC is powered on, stopped when powered off.

--- a/do.sh
+++ b/do.sh
@@ -81,7 +81,7 @@ function do_build() {
 		echo "Image exists already. Run $0 update if you want to update the existing build."
 		return 0
 	fi
-	docker build -t spotifyd .
+	docker build -t spotifyd:latest .
 	return $?
 }
 


### PR DESCRIPTION
Move the base image to Alpine Linux. This allows to shrink the docker image from 90MB to 16MB.